### PR TITLE
Add support for pprof builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made several code changes due to upgrade to latest version of Go
 - Fixed jq parsing issue when running local Snyk scans
 
+### Added
+
+- Added support for pprof builds
+
 ### Changes
 
 - Replace mux with chi router

--- a/Dockerfile.pprof
+++ b/Dockerfile.pprof
@@ -1,0 +1,86 @@
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Dockerfile for building power-control.
+
+# Build base just has the packages installed we need.
+FROM docker.io/library/golang:1.23-alpine AS build-base
+
+RUN set -ex \
+    && apk -U upgrade \
+    && apk add build-base
+
+# Base copies in the files we need to test/build.
+FROM build-base AS base
+
+RUN go env -w GO111MODULE=auto
+
+# Copy all the necessary files to the image.
+COPY cmd $GOPATH/src/github.com/OpenCHAMI/power-control/v2/cmd
+COPY go.mod $GOPATH/src/github.com/OpenCHAMI/power-control/v2/go.mod
+COPY go.sum $GOPATH/src/github.com/OpenCHAMI/power-control/v2/go.sum
+COPY internal $GOPATH/src/github.com/OpenCHAMI/power-control/v2/internal
+
+### Build Stage ###
+FROM base AS builder
+
+RUN set -ex  && go build -C $GOPATH/src/github.com/OpenCHAMI/power-control/v2/cmd/power-control -v -tags "musl pprof" -o /usr/local/bin/power-control
+
+### Final Stage ###
+
+FROM docker.io/alpine:3
+LABEL maintainer="Hewlett Packard Enterprise"
+EXPOSE 28007
+STOPSIGNAL SIGTERM
+
+RUN set -ex \
+    && apk -U upgrade \
+    && apk add curl jq
+
+# Get the power-control from the builder stage.
+COPY --from=builder /usr/local/bin/power-control /usr/local/bin/.
+COPY configs configs
+
+# Setup environment variables.
+ENV SMS_SERVER="http://cray-smd:27779"
+ENV LOG_LEVEL="INFO"
+ENV SERVICE_RESERVATION_VERBOSITY="INFO"
+ENV TRS_IMPLEMENTATION="LOCAL"
+ENV STORAGE="ETCD"
+ENV ETCD_HOST="etcd"
+ENV ETCD_PORT="2379"
+ENV HSMLOCK_ENABLED="true"
+ENV VAULT_ENABLED="true"
+ENV VAULT_ADDR="http://vault:8200"
+ENV VAULT_KEYPATH="secret/hms-creds"
+
+#DONT USES IN PRODUCTION; MOST WILL BREAK PROD!!!
+ENV VAULT_SKIP_VERIFY="true"
+ENV VAULT_TOKEN="hms"
+ENV CRAY_VAULT_AUTH_PATH="auth/token/create"
+ENV CRAY_VAULT_ROLE_FILE="/configs/namespace"
+ENV CRAY_VAULT_JWT_FILE="/configs/token"
+
+#nobody 65534:65534
+USER 65534:65534
+
+CMD ["sh", "-c", "power-control"]

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,7 @@ ct:
 
 ct_image:
 	docker build --no-cache -f test/ct/Dockerfile test/ct/ --tag cray-power-control-hmth-test:${VERSION}
+
+image-pprof:
+	docker build --pull ${DOCKER_ARGS} --tag '${NAME}-pprof:${VERSION}' -f Dockerfile.pprof .
+

--- a/internal/api/pprof.go
+++ b/internal/api/pprof.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http/pprof"
+	_ "net/http/pprof"
+
+	"github.com/gorilla/mux"
+)
+
+func RegisterPProfHandlers(router *mux.Router) {
+	// Main profiling entry point
+	router.HandleFunc("/v1/debug/pprof/", pprof.Index) // Index listing all pprof endpoints
+
+	// Specific profiling handlers
+	router.HandleFunc("/v1/debug/pprof/cmdline", pprof.Cmdline) // Command-line arguments
+	router.HandleFunc("/v1/debug/pprof/profile", pprof.Profile) // CPU profile (default: 30 seconds)
+	router.HandleFunc("/v1/debug/pprof/symbol", pprof.Symbol)   // Symbol resolution for addresses
+	router.HandleFunc("/v1/debug/pprof/trace", pprof.Trace)     // Execution trace (default: 1 second)
+
+	// Additional profiling endpoints
+	router.Handle("/v1/debug/pprof/allocs", pprof.Handler("allocs"))             // Heap allocation samples
+	router.Handle("/v1/debug/pprof/block", pprof.Handler("block"))               // Goroutine blocking events
+	router.Handle("/v1/debug/pprof/goroutine", pprof.Handler("goroutine"))       // Stack traces of all goroutines
+	router.Handle("/v1/debug/pprof/heap", pprof.Handler("heap"))                 // Memory heap profile
+	router.Handle("/v1/debug/pprof/mutex", pprof.Handler("mutex"))               // Mutex contention profile
+	router.Handle("/v1/debug/pprof/threadcreate", pprof.Handler("threadcreate")) // Stack traces of thread creation
+}

--- a/internal/api/pprof.go
+++ b/internal/api/pprof.go
@@ -1,3 +1,25 @@
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 package api
 
 import (

--- a/internal/api/pprof.go
+++ b/internal/api/pprof.go
@@ -1,24 +1,29 @@
-# MIT License
-#
-# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
+// This file contains the code to enable pprof profiling. It is only
+// included in the build when the 'pprof' build tag is set in the Dockerfile.
+//
+//go:build pprof
+
+/*
+ * (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 package api
 
@@ -26,10 +31,10 @@ import (
 	"net/http/pprof"
 	_ "net/http/pprof"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
 )
 
-func RegisterPProfHandlers(router *mux.Router) {
+func RegisterPProfHandlers(router *chi.Mux) {
 	// Main profiling entry point
 	router.HandleFunc("/v1/debug/pprof/", pprof.Index) // Index listing all pprof endpoints
 

--- a/internal/api/pprof_stub.go
+++ b/internal/api/pprof_stub.go
@@ -1,5 +1,6 @@
-// This file contains the code to enable pprof profiling. It is only
-// included in the build when the 'pprof' build tag is set in the Dockerfile.
+// This file contains a stub implementation of the RegisterPProfHandlers()
+// function which is a noop.  It is included in the build by default by
+// way of the 'pprof' build tag not being set in the Dockerfile.
 //
 //go:build !pprof
 

--- a/internal/api/pprof_stub.go
+++ b/internal/api/pprof_stub.go
@@ -1,27 +1,32 @@
-# MIT License
-#
-# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
-#
-# Permission is hereby granted, free of charge, to any person obtaining a
-# copy of this software and associated documentation files (the "Software"),
-# to deal in the Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute, sublicense,
-# and/or sell copies of the Software, and to permit persons to whom the
-# Software is furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included
-# in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
+// This file contains the code to enable pprof profiling. It is only
+// included in the build when the 'pprof' build tag is set in the Dockerfile.
+//
+//go:build !pprof
+
+/*
+ * (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 package api
 
-import "github.com/gorilla/mux"
+import "github.com/go-chi/chi/v5"
 
-func RegisterPProfHandlers(router *mux.Router) { }
+func RegisterPProfHandlers(router *chi.Mux) { }

--- a/internal/api/pprof_stub.go
+++ b/internal/api/pprof_stub.go
@@ -1,0 +1,5 @@
+package api
+
+import "github.com/gorilla/mux"
+
+func RegisterPProfHandlers(router *mux.Router) { }

--- a/internal/api/pprof_stub.go
+++ b/internal/api/pprof_stub.go
@@ -1,3 +1,25 @@
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 package api
 
 import "github.com/gorilla/mux"

--- a/internal/api/routers.go
+++ b/internal/api/routers.go
@@ -125,6 +125,10 @@ func NewRouter() *chi.Mux {
 		router.Method(route.Method, "/v1"+route.Pattern, handler)
 	}
 
+	// If the 'pprof' build tag is set, then this will register pprof handlers,
+	// otherwise this function is stubbed and will do nothing.
+	RegisterPProfHandlers(router)
+
 	return router
 }
 


### PR DESCRIPTION
## Summary and Scope

Added support for building a pprof enabled image. Profiling adds runtime overhead so the pprof enabled image is not used by default. It is meant to be a debug tool. In order to use the enabled pprof image, edit the deployment and append "-pprof" to the image name. For unstable developer builds, be sure to change the built timestamp as well.

## Issues and Related PRs

https://github.com/Cray-HPE/hms-power-control/pull/59