### PR TITLE
Set test storage engine via Actions matrix

### DIFF
--- a/.github/workflows/run_unit_test.yaml
+++ b/.github/workflows/run_unit_test.yaml
@@ -7,6 +7,7 @@ jobs:
   run_unit_tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         storage:
           - MEMORY

--- a/.github/workflows/run_unit_test.yaml
+++ b/.github/workflows/run_unit_test.yaml
@@ -21,4 +21,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose make
       - name: Run unit tests
+        env:
+          STORAGE: ${{ matrix.storage }}
         run: make unittest # this inherits STORAGE from the environment via Makefile directives

--- a/.github/workflows/run_unit_test.yaml
+++ b/.github/workflows/run_unit_test.yaml
@@ -6,6 +6,12 @@ on:
 jobs:
   run_unit_tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        storage:
+          - MEMORY
+          - ETCD
+          - POSTGRES
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -14,4 +20,4 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-compose make
       - name: Run unit tests
-        run: make unittest
+        run: make unittest # this inherits STORAGE from the environment via Makefile directives

--- a/Dockerfile.test.unit.Dockerfile
+++ b/Dockerfile.test.unit.Dockerfile
@@ -35,7 +35,6 @@ ENV SMS_SERVER="http://smd:27779"
 ENV LOG_LEVEL="INFO"
 ENV SERVICE_RESERVATION_VERBOSITY="ERROR"
 ENV TRS_IMPLEMENTATION="LOCAL"
-ENV STORAGE="BOTH"
 ENV ETCD_HOST="etcd"
 ENV ETCD_PORT="2379"
 ENV HSMLOCK_ENABLED="true"
@@ -59,6 +58,7 @@ COPY go.mod $GOPATH/src/github.com/OpenCHAMI/power-control/v2/go.mod
 COPY go.sum $GOPATH/src/github.com/OpenCHAMI/power-control/v2/go.sum
 
 CMD set -ex \
+    && echo "Testing with ${STORAGE} storage" \
     && ./scripts/wait-for-discovery.sh \
     && go version \
     && cd $GOPATH/src/github.com/OpenCHAMI/power-control/v2/ \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@
 # Service
 NAME    ?= cray-power-control
 VERSION ?= $(shell git describe --tags --always --abbrev=0)
+STORAGE ?= POSTGRES
 
 all: image unittest integration snyk ct ct_image
 
@@ -30,7 +31,7 @@ image:
 	docker build --pull ${DOCKER_ARGS} --tag '${NAME}:${VERSION}' .
 
 unittest:
-	./runUnitTest.sh
+	STORAGE=${STORAGE} ./runUnitTest.sh
 
 integration:
 	./runIntegration.sh

--- a/docker-compose.test.unit.yaml
+++ b/docker-compose.test.unit.yaml
@@ -10,6 +10,7 @@ services:
       - SMS_SERVER=http://smd:27779
       - VAULT_ENABLED=true
       - VAULT_KEYPATH=hms-creds
+      - STORAGE
     depends_on:
       - etcd
       - smd

--- a/internal/storage/distlock_postgres_impl.go
+++ b/internal/storage/distlock_postgres_impl.go
@@ -1,14 +1,16 @@
 package storage
 
 import (
+	"time"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/sirupsen/logrus"
-	"time"
 )
 
 type PostgresLockProvider struct {
-	logger *logrus.Logger
-	db     *sqlx.DB
+	logger   *logrus.Logger
+	db       *sqlx.DB
+	Duration time.Duration
 }
 
 func (p *PostgresLockProvider) Init(Logger *logrus.Logger) error {
@@ -25,13 +27,15 @@ func (p *PostgresLockProvider) Ping() error {
 }
 
 func (p *PostgresLockProvider) DistributedTimedLock(maxLockTime time.Duration) error {
+	p.Duration = maxLockTime
 	return nil
 }
 
 func (p *PostgresLockProvider) Unlock() error {
+	p.Duration = 0
 	return nil
 }
 
 func (p *PostgresLockProvider) GetDuration() time.Duration {
-	return 0
+	return p.Duration
 }

--- a/internal/storage/distlock_test.go
+++ b/internal/storage/distlock_test.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -106,26 +105,34 @@ func createDistLockProvider() (DistributedLockProvider, error) {
 }
 
 func TestMain(m *testing.M) {
-	var exitCode int
+	// TODO https://github.com/OpenCHAMI/power-control/issues/25
+	// The current test scaffolding expects that storage provider containers will spring fully-formed from the void,
+	// along with the environment information the provider Init() functions expect. This is partially handled through a
+	// dedicated test runner container, which configures the environment prior to invoking "go test". As the tests are
+	// already running inside a container, they can't spawn their own containers. The commented setup below is what
+	// we'd use if we could spawn our own containers; for now we just require something create them out of band.
 
+	//var exitCode int
 	// Start the storage backend container if needed
-	ctr, err := startStorageBackendContainer()
-	defer func() {
-		if ctr != nil {
-			if err := testcontainers.TerminateContainer(ctr); err != nil {
-				log.Printf("failed to terminate container: %s", err)
-				os.Exit(TEST_FAIL_CODE)
-			}
-		}
+	//
+	//ctr, err := startStorageBackendContainer()
+	//defer func() {
+	//	if ctr != nil {
+	//		if err := testcontainers.TerminateContainer(ctr); err != nil {
+	//			log.Printf("failed to terminate container: %s", err)
+	//			os.Exit(TEST_FAIL_CODE)
+	//		}
+	//	}
 
-		os.Exit(exitCode)
-	}()
+	//	os.Exit(exitCode)
+	//}()
 
-	if err != nil {
-		fmt.Printf("Error starting storage backend container: %v\n", err)
-		os.Exit(TEST_FAIL_CODE)
-	}
+	//if err != nil {
+	//	fmt.Printf("Error starting storage backend container: %v\n", err)
+	//	os.Exit(TEST_FAIL_CODE)
+	//}
 
+	var err error
 	storageProvider, err = createStorageProvider()
 	if err != nil {
 		fmt.Printf("Error creating storage provider: %v\n", err)
@@ -151,7 +158,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Run the tests
-	exitCode = m.Run()
+	m.Run()
 
 }
 

--- a/runUnitTest.sh
+++ b/runUnitTest.sh
@@ -32,6 +32,7 @@ ephCertDir=ephemeral_cert
 
 echo "COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME}"
 echo "COMPOSE_FILE: $COMPOSE_FILE"
+echo "STORAGE: ${STORAGE}"
 
 
 function cleanup() {


### PR DESCRIPTION
Add an Actions matrix for the storage engine to "unit" tests, which are functionally integration tests, and plumb it down to the docker-compose invocation that runs these tests.

Disable creation of test containers with a TODO for https://github.com/OpenCHAMI/power-control/issues/25

docker-compose for unit tests currently sets up Postgres but doesn't configure its envvars. We should probably avoid the container build setting that (as it currently does for etcd). The test Postgres should either match the defaults of `Init()` or it should provide information via the docker-compose environment configuration for the test container.

Add code to update the Postgres DistLock duration field when obtaining and releasing the lock, to pass the existing test.

This ignores the "integration" tests, because they [don't actually do anything](https://github.com/OpenCHAMI/power-control/blob/fc206aaa164af00340da76e31c68aef9eeebe77b/Dockerfile.integration.tests.Dockerfile#L39-L41).