### PR TITLE
chore: use interfaces without indirects

### DIFF
--- a/cmd/power-control/service.go
+++ b/cmd/power-control/service.go
@@ -298,9 +298,9 @@ func runPCS(pcs *pcsConfig, etcd *etcdConfig, postgres *storage.PostgresConfig) 
 
 	//DOMAIN CONFIGURATION
 	var domainGlobals domain.DOMAIN_GLOBALS
-	domainGlobals.NewGlobals(&BaseTRSTask, &TLOC_rf, &TLOC_svc, rfClient, svcClient,
-		rfClientLock, &Running, &DSP, &HSM, pcs.vaultEnabled,
-		&CS, &DLOCK, pcs.maxNumCompleted, pcs.expireTimeMins, podName)
+	domainGlobals.NewGlobals(&BaseTRSTask, TLOC_rf, TLOC_svc, rfClient, svcClient,
+		rfClientLock, &Running, DSP, HSM, pcs.vaultEnabled,
+		CS, DLOCK, pcs.maxNumCompleted, pcs.expireTimeMins, podName)
 
 	//Wait for vault PKI to respond for CA bundle.  Once this happens, re-do
 	//the globals.  This goroutine will run forever checking if the CA trust
@@ -362,7 +362,7 @@ func runPCS(pcs *pcsConfig, etcd *etcdConfig, postgres *storage.PostgresConfig) 
 				prevCaChain = caChain
 
 				//update RF tloc and rfclient to the global areas! //TODO im not sure what part of this code is still needed; im guessing part of it at least!
-				domainGlobals.RFTloc = &TLOC_rf
+				domainGlobals.RFTloc = TLOC_rf
 				domainGlobals.RFHttpClient = rfClient
 				//hsmGlob.RFTloc = &TLOC_rf
 				//hsmGlob.RFHttpClient = rfClient

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -66,13 +66,13 @@ func GetReadiness(w http.ResponseWriter, req *http.Request) {
 
 	//Check KVStore and dist locks
 
-	err = (*glb.DSP).Ping()
+	err = glb.DSP.Ping()
 	if err != nil {
 		logger.Log.Errorf("%s: Ping() failed to storage provider.", fname)
 		ready = false
 	}
 
-	err = (*glb.DistLock).Ping()
+	err = glb.DistLock.Ping()
 	if err != nil {
 		logger.Log.Errorf("%s: Ping() failed to dist lock provider.", fname)
 		ready = false
@@ -80,7 +80,7 @@ func GetReadiness(w http.ResponseWriter, req *http.Request) {
 
 	//Check HSM
 
-	err = (*glb.HSM).Ping()
+	err = glb.HSM.Ping()
 	if err != nil {
 		logger.Log.Errorf("%s: Ping() failed to HSM.", fname)
 		ready = false
@@ -89,7 +89,7 @@ func GetReadiness(w http.ResponseWriter, req *http.Request) {
 	//Check Vault
 
 	if glb.VaultEnabled {
-		if !(*glb.CS).IsReady() {
+		if !glb.CS.IsReady() {
 			logger.Log.Errorf("%s: Cred store is not ready.", fname)
 			ready = false
 		}
@@ -97,7 +97,7 @@ func GetReadiness(w http.ResponseWriter, req *http.Request) {
 
 	//Check TRS
 
-	alive, terr := (*glb.RFTloc).Alive()
+	alive, terr := glb.RFTloc.Alive()
 	if !alive || (terr != nil) {
 		logger.Log.Infof("%s: TRS not alive, err: %v", fname, err)
 		ready = false
@@ -132,7 +132,7 @@ func GetHealth(w http.ResponseWriter, req *http.Request) {
 	if glb.DSP == nil {
 		rspData.KvStore = unconnected
 	} else {
-		err = (*glb.DSP).Ping()
+		err = glb.DSP.Ping()
 		if err == nil {
 			rspData.KvStore = connected + sep + responsive
 		} else {
@@ -143,7 +143,7 @@ func GetHealth(w http.ResponseWriter, req *http.Request) {
 	if glb.DistLock == nil {
 		rspData.DistLocking = unconnected
 	} else {
-		err = (*glb.DistLock).Ping()
+		err = glb.DistLock.Ping()
 		if err == nil {
 			rspData.DistLocking = connected + sep + responsive
 		} else {
@@ -156,7 +156,7 @@ func GetHealth(w http.ResponseWriter, req *http.Request) {
 	if glb.HSM == nil {
 		rspData.StateManager = unconnected
 	} else {
-		err = (*glb.HSM).Ping()
+		err = glb.HSM.Ping()
 		if err == nil {
 			rspData.StateManager = connected + sep + responsive
 		} else {
@@ -170,7 +170,7 @@ func GetHealth(w http.ResponseWriter, req *http.Request) {
 		if glb.CS == nil {
 			rspData.Vault = unconnected
 		} else {
-			if (*glb.CS).IsReady() {
+			if glb.CS.IsReady() {
 				rspData.Vault = connected + sep + responsive
 			} else {
 				rspData.Vault = connected + sep + unresponsive
@@ -185,7 +185,7 @@ func GetHealth(w http.ResponseWriter, req *http.Request) {
 	if glb.RFTloc == nil {
 		rspData.TaskRunner = unconnected
 	} else {
-		alive, terr := (*glb.RFTloc).Alive()
+		alive, terr := glb.RFTloc.Alive()
 		if terr != nil {
 			rspData.TaskRunner = unconnected + sep + unresponsive
 		} else {
@@ -196,7 +196,7 @@ func GetHealth(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 
-		ktype := reflect.TypeOf((*glb.RFTloc)).String()
+		ktype := reflect.TypeOf(glb.RFTloc).String()
 		ktypeTL := strings.ToLower(ktype)
 		if strings.Contains(ktypeTL, "local") {
 			rspData.TaskRunner = rspData.TaskRunner + sep + localmode

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -112,9 +112,9 @@ func setupGlobals(suite *Models_TS) {
 	}
 
 	var domainGlobals domain.DOMAIN_GLOBALS
-	domainGlobals.NewGlobals(nil, &TLOC_rf, nil, nil, nil,
-		nil, &Running, &DSP, &HSM, (ve != ""),
-		&CS, &DLOCK, 20000, 1440, "health_test-pod")
+	domainGlobals.NewGlobals(nil, TLOC_rf, nil, nil, nil,
+		nil, &Running, DSP, HSM, (ve != ""),
+		CS, DLOCK, 20000, 1440, "health_test-pod")
 	domain.Init(&domainGlobals)
 
 }

--- a/internal/domain/globals.go
+++ b/internal/domain/globals.go
@@ -46,33 +46,33 @@ func Init(glob *DOMAIN_GLOBALS) {
 type DOMAIN_GLOBALS struct {
 	CAUri            string
 	BaseTRSTask      *trs_http_api.HttpTask
-	RFTloc           *trs_http_api.TrsAPI
-	HSMTloc          *trs_http_api.TrsAPI
+	RFTloc           trs_http_api.TrsAPI
+	HSMTloc          trs_http_api.TrsAPI
 	RFClientLock     *sync.RWMutex
 	Running          *bool
-	DSP              *storage.StorageProvider
-	HSM              *hsm.HSMProvider
+	DSP              storage.StorageProvider
+	HSM              hsm.HSMProvider
 	RFHttpClient     *hms_certs.HTTPClientPair
 	SVCHttpClient    *hms_certs.HTTPClientPair
 	RFTransportReady *bool
 	VaultEnabled     bool
-	CS               *credstore.CredStoreProvider
-	DistLock         *storage.DistributedLockProvider
+	CS               credstore.CredStoreProvider
+	DistLock         storage.DistributedLockProvider
 	MaxNumCompleted  int
 	ExpireTimeMins   int
 	PodName          string
 }
 
 func (g *DOMAIN_GLOBALS) NewGlobals(base *trs_http_api.HttpTask,
-	tlocRF *trs_http_api.TrsAPI,
-	tlocSVC *trs_http_api.TrsAPI,
+	tlocRF trs_http_api.TrsAPI,
+	tlocSVC trs_http_api.TrsAPI,
 	clientRF *hms_certs.HTTPClientPair,
 	clientSVC *hms_certs.HTTPClientPair,
 	rfClientLock *sync.RWMutex,
-	running *bool, dsp *storage.StorageProvider,
-	hsm *hsm.HSMProvider, vaultEnabled bool,
-	credStore *credstore.CredStoreProvider,
-	distLock *storage.DistributedLockProvider,
+	running *bool, dsp storage.StorageProvider,
+	hsm hsm.HSMProvider, vaultEnabled bool,
+	credStore credstore.CredStoreProvider,
+	distLock storage.DistributedLockProvider,
 	maxNumCompleted int, expireTimeMins int,
 	podName string) {
 	g.BaseTRSTask = base

--- a/internal/domain/power-cap_test.go
+++ b/internal/domain/power-cap_test.go
@@ -70,7 +70,7 @@ func TestDoPowerCapTask(t *testing.T) {
 
 	task := model.NewPowerCapSnapshotTask(params, GLOB.ExpireTimeMins)
 
-	err = (*GLOB.DSP).StorePowerCapTask(task)
+	err = GLOB.DSP.StorePowerCapTask(task)
 	if err != nil {
 		t.Errorf("ERROR doPowerCapTask(1) failed - %s", err.Error())
 		return
@@ -119,7 +119,7 @@ func TestDoPowerCapTask(t *testing.T) {
 
 	task2 := model.NewPowerCapPatchTask(params2, GLOB.ExpireTimeMins)
 
-	err = (*GLOB.DSP).StorePowerCapTask(task2)
+	err = GLOB.DSP.StorePowerCapTask(task2)
 	if err != nil {
 		t.Errorf("ERROR doPowerCapTask(2) failed - %s", err.Error())
 		return
@@ -185,13 +185,13 @@ func TestDoPowerCapTask(t *testing.T) {
 	//       for the convenience of having 2 tasks
 	//       already in storage.
 	/////////
-	expiredTask, err := (*GLOB.DSP).GetPowerCapTask(task2.TaskID)
+	expiredTask, err := GLOB.DSP.GetPowerCapTask(task2.TaskID)
 	if err != nil {
 		t.Errorf("ERROR powerCapReaper() failed - %s", err.Error())
 		return
 	}
 	expiredTask.AutomaticExpirationTime = time.Now().Add(-3 * time.Second)
-	err = (*GLOB.DSP).StorePowerCapTask(expiredTask)
+	err = GLOB.DSP.StorePowerCapTask(expiredTask)
 	if err != nil {
 		t.Errorf("ERROR powerCapReaper() failed - %s", err.Error())
 		return
@@ -277,8 +277,8 @@ func doSetup() error {
 	}
 	HSM.Init(&hsmGlob)
 
-	domainGlobals.NewGlobals(&BaseTRSTask, &TLOC_rf, &TLOC_svc, nil, nil,
-		rfClientLock, &Running, &DSP, &HSM, VaultEnabled, nil, nil,
+	domainGlobals.NewGlobals(&BaseTRSTask, TLOC_rf, TLOC_svc, nil, nil,
+		rfClientLock, &Running, DSP, HSM, VaultEnabled, nil, nil,
 		20000, 1440, "power-cap_test-pod")
 	Init(&domainGlobals)
 	return nil

--- a/internal/domain/power-status.go
+++ b/internal/domain/power-status.go
@@ -416,7 +416,7 @@ func getVaultCredsAll(compMap map[string]*componentPowerInfo) error {
 	//The credstore layer caches creds, so this should be fast.
 
 	for k, v := range compMap {
-		un, pw, err = (ccStore).GetControllerCredentials(k)
+		un, pw, err = ccStore.GetControllerCredentials(k)
 		if err != nil {
 			return fmt.Errorf("ERROR: Can't get BMC creds for '%s': %v", k, err)
 		}
@@ -1004,13 +1004,13 @@ func toPCSPowerActions(rfPowerActions []string) []string {
 // If it has been awhile since the last update, attempt to
 // become the new master.
 func getPowerStatusMaster() bool {
-	lockErr := (distLocker).DistributedTimedLock(distLockMaxTime)
+	lockErr := distLocker.DistributedTimedLock(distLockMaxTime)
 	if lockErr != nil {
 		// Someone else is already doing this check which means we aren't going to be master.
 		return false
 	}
 	defer func() {
-		unlockErr := (distLocker).Unlock()
+		unlockErr := distLocker.Unlock()
 		if unlockErr != nil {
 			glogger.Errorf("ERROR releasing distributed lock: %v", unlockErr)
 		}

--- a/internal/domain/power-status_test.go
+++ b/internal/domain/power-status_test.go
@@ -110,8 +110,8 @@ func glbInit() {
 		DLOCK = tdLock
 		DLOCK.Init(tlogger)
 
-		domGlb.NewGlobals(nil, &TLOC_rf, nil, nil, svcClient, &sync.RWMutex{},
-			&running, &DSP, &HSM, vaultEnabled, &CS, &DLOCK, 20000, 1440,
+		domGlb.NewGlobals(nil, TLOC_rf, nil, nil, svcClient, &sync.RWMutex{},
+			&running, DSP, HSM, vaultEnabled, CS, DLOCK, 20000, 1440,
 			"power-status_test-pod")
 
 		tlogger.Errorf("DLOCK: '%v', Globals: '%v'", DLOCK, domGlb)
@@ -227,7 +227,7 @@ func nodePower(node *hsm.HsmData, action string) error {
 		return fmt.Errorf("Vault not enabled, can't get creds for BMC.")
 	}
 
-	un, pw, cerr := (*domGlb.CS).GetControllerCredentials(node.BaseData.ID)
+	un, pw, cerr := domGlb.CS.GetControllerCredentials(node.BaseData.ID)
 	if cerr != nil {
 		return fmt.Errorf("Can't get creds for %s: %v", node.BaseData.ID, cerr)
 	}
@@ -289,7 +289,7 @@ func (suite *PwrStat_TS) Test_PowerStatusMonitor() {
 
 	//Get a list of components from HSM
 
-	compMap, cerr := (*domGlb.HSM).FillHSMData([]string{"all"})
+	compMap, cerr := domGlb.HSM.FillHSMData([]string{"all"})
 	suite.Assert().Equal(nil, cerr, "FillHSMData() failed: %v", cerr)
 
 	var comps []string

--- a/internal/domain/transitions_test.go
+++ b/internal/domain/transitions_test.go
@@ -132,9 +132,9 @@ func (ts *Transitions_TS) SetupSuite() {
 	HSM.Init(&hsmGlob)
 	ts.hsmURL = hsmGlob.SMUrl
 
-	domainGlobals.NewGlobals(&BaseTRSTask, &TLOC_rf, &TLOC_svc, nil, svcClient,
-		rfClientLock, &Running, &DSP, &HSM, enableVault, &CS,
-		&DLOCK, 20000, 1440, "transitions_test-pod")
+	domainGlobals.NewGlobals(&BaseTRSTask, TLOC_rf, TLOC_svc, nil, svcClient,
+		rfClientLock, &Running, DSP, HSM, enableVault, CS,
+		DLOCK, 20000, 1440, "transitions_test-pod")
 	Init(&domainGlobals)
 
 	// Calling PowerStatusMonitorInit() is required to initialize the
@@ -184,7 +184,7 @@ func (ts *Transitions_TS) TestDoTransition() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	doTransition(testTransition.TransitionID)
 	resultsPb = GetTransition(testTransition.TransitionID)
 	results = resultsPb.Obj.(model.TransitionResp)
@@ -207,7 +207,7 @@ func (ts *Transitions_TS) TestDoTransition() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	doTransition(testTransition.TransitionID)
 	resultsPb = GetTransition(testTransition.TransitionID)
 	results = resultsPb.Obj.(model.TransitionResp)
@@ -237,7 +237,7 @@ func (ts *Transitions_TS) TestDoTransition() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	doTransition(testTransition.TransitionID)
 	resultsPb = GetTransition(testTransition.TransitionID)
 	results = resultsPb.Obj.(model.TransitionResp)
@@ -260,7 +260,7 @@ func (ts *Transitions_TS) TestDoTransition() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	go doTransition(testTransition.TransitionID)
 	// Wait for completion
 	for i := 0; i < 60; i++ {
@@ -310,26 +310,26 @@ func (ts *Transitions_TS) TestDoTransition() {
 	task.Operation = model.Operation_Off
 	task.State = model.TaskState_Waiting
 	testTransition.TaskIDs = append(testTransition.TaskIDs, task.TaskID)
-	(*GLOB.DSP).StoreTransitionTask(task)
+	GLOB.DSP.StoreTransitionTask(task)
 	task = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task.Xname = "x0c0s2b0n0"
 	task.Operation = model.Operation_Off
 	task.State = model.TaskState_Sending
 	testTransition.TaskIDs = append(testTransition.TaskIDs, task.TaskID)
-	(*GLOB.DSP).StoreTransitionTask(task)
+	GLOB.DSP.StoreTransitionTask(task)
 	task = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task.Xname = "x0c0s1"
 	task.Operation = model.Operation_Init
 	task.State = model.TaskState_GatherData
 	testTransition.TaskIDs = append(testTransition.TaskIDs, task.TaskID)
-	(*GLOB.DSP).StoreTransitionTask(task)
+	GLOB.DSP.StoreTransitionTask(task)
 	task = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task.Xname = "x0c0s2"
 	task.Operation = model.Operation_Init
 	task.State = model.TaskState_GatherData
 	testTransition.TaskIDs = append(testTransition.TaskIDs, task.TaskID)
-	(*GLOB.DSP).StoreTransitionTask(task)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransitionTask(task)
+	GLOB.DSP.StoreTransition(testTransition)
 	go doTransition(testTransition.TransitionID)
 	// Wait for completion
 	for i := 0; i < 60; i++ {
@@ -381,7 +381,7 @@ func (ts *Transitions_TS) TestAbortTransitionID() {
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
 	testTransition.Status = model.TransitionStatusCompleted
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	resultsPb = AbortTransitionID(testTransition.TransitionID)
 	ts.Assert().Equal(http.StatusBadRequest, resultsPb.StatusCode,
 		"Test 2 failed with status code, %d. Expected %d",
@@ -398,7 +398,7 @@ func (ts *Transitions_TS) TestAbortTransitionID() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	resultsPb = AbortTransitionID(testTransition.TransitionID)
 	ts.Assert().Equal(http.StatusAccepted, resultsPb.StatusCode,
 		"Test 3 failed with status code, %d. Expected %d",
@@ -450,7 +450,7 @@ func (ts *Transitions_TS) TestCheckAbort() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	resultsAbort, err = checkAbort(testTransition)
 	ts.Assert().Empty(err,
 		"Test 2 failed with error, %v. Expected %s",
@@ -464,7 +464,7 @@ func (ts *Transitions_TS) TestCheckAbort() {
 	/////////
 	t.Logf("Test 3 - checkAbort() Exists, w\\ abort.")
 	testTransition.Status = model.TransitionStatusAbortSignaled
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	resultsAbort, err = checkAbort(testTransition)
 	ts.Assert().Empty(err,
 		"Test 3 failed with error, %v. Expected %s",
@@ -501,21 +501,21 @@ func (ts *Transitions_TS) TestDoAbort() {
 	task1 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task1.Xname = "x0c0s1b0n0"
 	task1.Status = model.TransitionTaskStatusNew
-	(*GLOB.DSP).StoreTransitionTask(task1)
+	GLOB.DSP.StoreTransitionTask(task1)
 	task2 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task2.Xname = "x0c0s2b0n0"
 	task2.Status = model.TransitionTaskStatusInProgress
-	(*GLOB.DSP).StoreTransitionTask(task2)
+	GLOB.DSP.StoreTransitionTask(task2)
 	task3 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task3.Xname = "x0c0s1"
 	task3.Status = model.TransitionTaskStatusFailed
 	task3.Error = "My Error"
 	task3.StatusDesc = "My description"
-	(*GLOB.DSP).StoreTransitionTask(task3)
+	GLOB.DSP.StoreTransitionTask(task3)
 	task4 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task4.Xname = "x0c0s2"
 	task4.Status = model.TransitionTaskStatusSucceeded
-	(*GLOB.DSP).StoreTransitionTask(task4)
+	GLOB.DSP.StoreTransitionTask(task4)
 	testXnameMap := map[string]*TransitionComponent{
 		"x0c0s1b0n0": {Task: &task1},
 		"x0c0s2b0n0": {Task: &task2},
@@ -564,10 +564,10 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 		},
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	xnames := []string{"x0c0s1b0n0", "x0c0s2b0n0", "x0c0s1", "x0c0s2"}
 	pStates, _, _ := getPowerStateHierarchy(xnames)
-	hsmData, _ := (*GLOB.HSM).FillHSMData(xnames)
+	hsmData, _ := GLOB.HSM.FillHSMData(xnames)
 	task1 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task1.Xname = "x0c0s1b0n0"
 	pState1 := pStates["x0c0s1b0n0"]
@@ -576,7 +576,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s1b0n0"].AllowableActions {
 		actions1[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task1)
+	GLOB.DSP.StoreTransitionTask(task1)
 	task2 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task2.Xname = "x0c0s2b0n0"
 	pState2 := pStates["x0c0s2b0n0"]
@@ -585,7 +585,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s2b0n0"].AllowableActions {
 		actions2[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task2)
+	GLOB.DSP.StoreTransitionTask(task2)
 	task3 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task3.Xname = "x0c0s1"
 	pState3 := pStates["x0c0s1"]
@@ -594,7 +594,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s1"].AllowableActions {
 		actions3[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task3)
+	GLOB.DSP.StoreTransitionTask(task3)
 	task4 := model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task4.Xname = "x0c0s2"
 	pState4 := pStates["x0c0s2"]
@@ -603,7 +603,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s2"].AllowableActions {
 		actions4[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task4)
+	GLOB.DSP.StoreTransitionTask(task4)
 
 	testXnameMap = map[string]*TransitionComponent{
 		"x0c0s1b0n0": {
@@ -672,10 +672,10 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	}
 	testTransition, _ = model.ToTransition(testParams, GLOB.ExpireTimeMins)
 	testTransition.Status = model.TransitionStatusInProgress
-	(*GLOB.DSP).StoreTransition(testTransition)
+	GLOB.DSP.StoreTransition(testTransition)
 	xnames = []string{"x0c0s1b0n0", "x0c0s2b0n0", "x0c0s1", "x0c0s2"}
 	pStates, _, _ = getPowerStateHierarchy(xnames)
-	hsmData, _ = (*GLOB.HSM).FillHSMData(xnames)
+	hsmData, _ = GLOB.HSM.FillHSMData(xnames)
 	task1 = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task1.Xname = "x0c0s1b0n0"
 	task1.Status = model.TransitionTaskStatusInProgress
@@ -687,7 +687,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s1b0n0"].AllowableActions {
 		actions1[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task1)
+	GLOB.DSP.StoreTransitionTask(task1)
 	task2 = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task2.Xname = "x0c0s2b0n0"
 	task2.Operation = model.Operation_Off
@@ -698,7 +698,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s2b0n0"].AllowableActions {
 		actions2[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task2)
+	GLOB.DSP.StoreTransitionTask(task2)
 	task3 = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task3.Xname = "x0c0s1"
 	task3.Operation = model.Operation_Init
@@ -709,7 +709,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s1"].AllowableActions {
 		actions3[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task3)
+	GLOB.DSP.StoreTransitionTask(task3)
 	task4 = model.NewTransitionTask(testTransition.TransitionID, testTransition.Operation)
 	task4.Xname = "x0c0s2"
 	task4.Operation = model.Operation_Init
@@ -720,7 +720,7 @@ func (ts *Transitions_TS) TestSequenceComponents() {
 	for _, action := range hsmData["x0c0s2"].AllowableActions {
 		actions4[strings.ToLower(action)] = action
 	}
-	(*GLOB.DSP).StoreTransitionTask(task4)
+	GLOB.DSP.StoreTransitionTask(task4)
 
 	testXnameMap = map[string]*TransitionComponent{
 		"x0c0s1b0n0": {
@@ -799,7 +799,7 @@ func (ts *Transitions_TS) TestGetPowerSupplies() {
 		ManagementState: model.ManagementStateFilter_available.String(),
 		LastUpdated:     time.Now(),
 	}
-	(*GLOB.DSP).StorePowerStatus(connectorPowerStatus)
+	GLOB.DSP.StorePowerStatus(connectorPowerStatus)
 
 	results = getPowerSupplies(&testParams)
 
@@ -834,7 +834,7 @@ func (ts *Transitions_TS) TestGetPowerSupplies() {
 		ManagementState: model.ManagementStateFilter_available.String(),
 		LastUpdated:     time.Now(),
 	}
-	(*GLOB.DSP).StorePowerStatus(connectorPowerStatus)
+	GLOB.DSP.StorePowerStatus(connectorPowerStatus)
 
 	results = getPowerSupplies(&testParams)
 


### PR DESCRIPTION
## Summary and Scope

Do not dereference interface fields and vars, and pass struct pointers to functions that accept interfaces. Pointers to structs with the appropriate methods satisfy interfaces and are the standard means of passing interface arguments. Using pointers to interfaces requires weird type contortions.

This change is a backwards compatible code cleanliness change, and does not affect functionality.

# Testing

Basically, if `go vet` likes it, it's good to go. Don't expect there's anything CI can find that the compiler can, but it's running anyway :shrug: 

## Issues and Related PRs

N/a, found working on something else.

## Risks and Mitigations

Hopefully unlikely to cause conflicts, since these are largely simple function calls, but ideally this should be upstreamed.

## Pull Request Checklist

- [ ] ~Version number(s) incremented, if applicable~
- [ ] ~Copyrights updated~
- [x] License file intact
- [x] Target branch correct
- [ ] ~CHANGELOG.md updated~ code only
- [x] Testing is appropriate and complete, if applicable