### PR TITLE
feat: add power cap to Postgres storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/OpenCHAMI/jwtauth/v5 v5.0.0-20240321222802-e6cb468a2a18
 	github.com/OpenCHAMI/smd/v2 v2.17.7
 	github.com/go-chi/chi/v5 v5.2.1
+	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/uuid/v5 v5.3.2 h1:2jfO8j3XgSwlz/wHqemAEugfnTlikAYHhnqQ8Xh4fE0=
+github.com/gofrs/uuid/v5 v5.3.2/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
 github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/internal/domain/power-cap.go
+++ b/internal/domain/power-cap.go
@@ -324,7 +324,8 @@ func buildPowerCapResponse(task model.PowerCapTask, ops []model.PowerCapOperatio
 		TaskStatus:              task.TaskStatus,
 	}
 
-	// Is a compressed record
+	// task.IsCompressed == true when the task is complete. compressAndCompleteTask populates a summary of the task's
+	// operations in TaskCounts and Components.
 	if task.IsCompressed {
 		rsp.TaskCounts = task.TaskCounts
 		if full {
@@ -333,6 +334,7 @@ func buildPowerCapResponse(task model.PowerCapTask, ops []model.PowerCapOperatio
 		return rsp
 	}
 
+	// for incomplete tasks, we build the task count and component list from the currently active set of operations.
 	counts := model.PowerCapTaskCounts{}
 	componentMap := make(map[string]model.PowerCapComponent)
 	for _, op := range ops {

--- a/internal/storage/storage_postgres_power_cap_test.go
+++ b/internal/storage/storage_postgres_power_cap_test.go
@@ -1,0 +1,246 @@
+//go:build integration_tests
+
+package storage
+
+import (
+	"time"
+
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+
+	"github.com/OpenCHAMI/power-control/v2/internal/model"
+)
+
+// TestPowerCapTaskGetSet tests setting and getting a single power cap task.
+func (s *StorageTestSuite) TestPowerCapTaskGetSet() {
+	params := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
+	}
+
+	task := model.NewPowerCapSnapshotTask(params, 20)
+
+	// time handling between golang and postgres has some annoying nuances. https://github.com/jackc/pgx/issues/1195
+	// provides some background. tl;dr is that we lose nanosecond precision we do not have go's embedded timezones
+	// after retrieval. we should consider handling this elsewhere, but it's a minor issue--the times are correct
+	// even if their exact representation differs. setting UTC and truncating to us here allows these to match without
+	// duration checks
+	task.TaskCreateTime = task.TaskCreateTime.Truncate(time.Microsecond).UTC()
+	task.AutomaticExpirationTime = task.AutomaticExpirationTime.Truncate(time.Microsecond).UTC()
+
+	err := s.sp.StorePowerCapTask(task)
+	s.Require().NoError(err)
+
+	gotTask, err := s.sp.GetPowerCapTask(task.TaskID)
+	s.Require().NoError(err)
+
+	s.Require().NoError(err)
+	s.Require().Equal(task.TaskID, gotTask.TaskID)
+	s.Require().Equal(task.Type, gotTask.Type)
+	s.Require().Equal(task.TaskCreateTime, gotTask.TaskCreateTime)
+	s.Require().Equal(task.AutomaticExpirationTime, gotTask.AutomaticExpirationTime)
+	s.Require().Equal(task.TaskStatus, gotTask.TaskStatus)
+	s.Require().Equal(task.SnapshotParameters, gotTask.SnapshotParameters)
+	s.Require().Equal(task.PatchParameters, gotTask.PatchParameters)
+
+	// these are only set for completed tasks
+	s.Require().False(gotTask.IsCompressed)
+	s.Require().Empty(gotTask.TaskCounts)
+	s.Require().Empty(gotTask.Components)
+}
+
+// TestPowerCapTaskGetSet tests setting a single power cap task, updating it following compression, and retrieving the
+// compressed task after.
+func (s *StorageTestSuite) TestPowerCapTaskCompressedGetSet() {
+	params := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
+	}
+
+	task := model.NewPowerCapSnapshotTask(params, 20)
+	properType := "ProperType"
+	task.Type = properType
+	err := s.sp.StorePowerCapTask(task)
+	s.Require().NoError(err)
+
+	// these are faked. Normally domain.compressAndCompleteTask() calculates them from the operation list, but all this
+	// really cares about is that they're not empty now, and that the second store operation saves them
+	task.IsCompressed = true
+	task.TaskCounts = model.PowerCapTaskCounts{
+		Total:       10,
+		New:         2,
+		InProgress:  2,
+		Failed:      2,
+		Succeeded:   2,
+		Unsupported: 2,
+	}
+	task.Components = []model.PowerCapComponent{
+		{
+			Xname: "x0c0s0b0n1",
+		},
+		{
+			Xname: "x1c0s0b0n1",
+		},
+	}
+
+	task.Type = "BogusType"
+
+	err = s.sp.StorePowerCapTask(task)
+	s.Require().NoError(err)
+
+	gotTask, err := s.sp.GetPowerCapTask(task.TaskID)
+	s.Require().NoError(err)
+
+	s.Require().NoError(err)
+	s.Require().Equal(task.TaskID, gotTask.TaskID)
+	// this should _not_ have changed after the second update
+	s.Require().Equal(properType, gotTask.Type)
+	s.Require().Equal(task.TaskStatus, gotTask.TaskStatus)
+	s.Require().Equal(task.SnapshotParameters, gotTask.SnapshotParameters)
+	s.Require().Equal(task.PatchParameters, gotTask.PatchParameters)
+
+	s.Require().True(gotTask.IsCompressed)
+	s.Require().Equal(task.TaskCounts, gotTask.TaskCounts)
+	s.Require().Equal(task.Components, gotTask.Components)
+}
+
+// TestPowerCapOperationGetSet tests setting and getting a single power cap operation.
+func (s *StorageTestSuite) TestPowerCapOperationGetSet() {
+	params := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
+	}
+	task := model.NewPowerCapSnapshotTask(params, 20)
+	err := s.sp.StorePowerCapTask(task)
+	s.Require().NoError(err)
+
+	snapshotType := "snapshot"
+	op := model.NewPowerCapOperation(task.TaskID, snapshotType)
+
+	// how do you get one of these naturally? do you even, or are they always tacked on after retrieval?
+	limMax := 100
+	limMin := 50
+	pup := 25
+	op.Component = model.PowerCapComponent{
+		Xname: "x0c0s0b0n0",
+		Error: "",
+		Limits: &model.PowerCapabilities{
+			HostLimitMax: &limMax,
+			HostLimitMin: &limMin,
+			PowerupPower: &pup,
+		},
+	}
+
+	err = s.sp.StorePowerCapOperation(op)
+	s.Require().NoError(err)
+
+	gotOp, err := s.sp.GetPowerCapOperation(task.TaskID, op.OperationID)
+	s.Require().NoError(err)
+
+	s.Require().NoError(err)
+	s.Require().Equal(op.OperationID, gotOp.OperationID)
+	s.Require().Equal(op.TaskID, gotOp.TaskID)
+	s.Require().Equal(op.Type, gotOp.Type)
+	s.Require().Equal(op.Status, gotOp.Status)
+	s.Require().Equal(op.Component, gotOp.Component)
+
+	op.Status = "MysteriousTestStatus"
+	op.Type = "MysteriousTestType"
+	err = s.sp.StorePowerCapOperation(op)
+	s.Require().NoError(err)
+
+	// we should be able to update status, but not other fields
+	gotOp, err = s.sp.GetPowerCapOperation(task.TaskID, op.OperationID)
+	s.Require().NoError(err)
+	s.Require().Equal(snapshotType, gotOp.Type)
+	s.Require().Equal("MysteriousTestStatus", gotOp.Status)
+}
+
+// TestPowerCapTaskDelete tests deleting a single power cap task.
+func (s *StorageTestSuite) TestPowerCapTaskDelete() {
+	params := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
+	}
+	task := model.NewPowerCapSnapshotTask(params, 20)
+	err := s.sp.StorePowerCapTask(task)
+	s.Require().NoError(err)
+
+	_, err = s.sp.GetPowerCapTask(task.TaskID)
+	s.Require().NoError(err)
+
+	err = s.sp.DeletePowerCapTask(task.TaskID)
+	s.Require().NoError(err)
+
+	_, err = s.sp.GetPowerCapTask(task.TaskID)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "could not retrieve power cap task")
+
+}
+
+// TestPowerCapTaskDelete tests deleting a single power cap operation.
+func (s *StorageTestSuite) TestPowerCapOperationDelete() {
+	params := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
+	}
+	task := model.NewPowerCapSnapshotTask(params, 20)
+	err := s.sp.StorePowerCapTask(task)
+	s.Require().NoError(err)
+
+	op := model.NewPowerCapOperation(task.TaskID, "snapshot")
+
+	err = s.sp.StorePowerCapOperation(op)
+	s.Require().NoError(err)
+
+	_, err = s.sp.GetPowerCapOperation(task.TaskID, op.OperationID)
+	s.Require().NoError(err)
+
+	err = s.sp.DeletePowerCapOperation(task.TaskID, op.OperationID)
+	s.Require().NoError(err)
+
+	_, err = s.sp.GetPowerCapOperation(task.TaskID, op.OperationID)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "could not retrieve power cap operation")
+}
+
+// TestPowerCapMultiple tests inserting and retrieving multiple associated resources.
+func (s *StorageTestSuite) TestPowerCapMultiple() {
+	paramsA := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
+	}
+	taskA := model.NewPowerCapSnapshotTask(paramsA, 20)
+	err := s.sp.StorePowerCapTask(taskA)
+	s.Require().NoError(err)
+
+	paramsB := model.PowerCapSnapshotParameter{
+		Xnames: []string{"x0c0s0b0n1", "x0c0s1b0n1"},
+	}
+	taskB := model.NewPowerCapSnapshotTask(paramsB, 20)
+	err = s.sp.StorePowerCapTask(taskB)
+	s.Require().NoError(err)
+
+	opA1 := model.NewPowerCapOperation(taskA.TaskID, "alpha")
+	opA2 := model.NewPowerCapOperation(taskA.TaskID, "bravo")
+
+	opB1 := model.NewPowerCapOperation(taskB.TaskID, "xray")
+	opB2 := model.NewPowerCapOperation(taskB.TaskID, "yankee")
+	opB3 := model.NewPowerCapOperation(taskB.TaskID, "zulu")
+
+	for _, op := range []model.PowerCapOperation{opA1, opA2, opB1, opB2, opB3} {
+		err := s.sp.StorePowerCapOperation(op)
+		s.Require().NoError(err)
+	}
+
+	tasks, err := s.sp.GetAllPowerCapTasks()
+	s.Require().NoError(err)
+	s.Require().Len(tasks, 2)
+
+	opsA, err := s.sp.GetAllPowerCapOperationsForTask(taskA.TaskID)
+	s.Require().NoError(err)
+	s.Require().Len(opsA, 2)
+
+	opsB, err := s.sp.GetAllPowerCapOperationsForTask(taskB.TaskID)
+	s.Require().NoError(err)
+	s.Require().Len(opsB, 3)
+
+	s.Require().Contains([]string{opsA[0].Type, opsA[1].Type}, "alpha")
+	s.Require().Contains([]string{opsA[0].Type, opsA[1].Type}, "bravo")
+	s.Require().Contains([]string{opsB[0].Type, opsB[1].Type, opsB[2].Type}, "xray")
+	s.Require().Contains([]string{opsB[0].Type, opsB[1].Type, opsB[2].Type}, "yankee")
+	s.Require().Contains([]string{opsB[0].Type, opsB[1].Type, opsB[2].Type}, "zulu")
+}

--- a/internal/storage/storage_postgres_power_cap_test.go
+++ b/internal/storage/storage_postgres_power_cap_test.go
@@ -198,7 +198,7 @@ func (s *StorageTestSuite) TestPowerCapOperationDelete() {
 	s.Require().ErrorContains(err, "could not retrieve power cap operation")
 }
 
-// TestPowerCapMultiple tests inserting and retrieving multiple associated resources.
+// TestPowerCapMultiple tests inserting, retrieving, and deleting multiple associated resources.
 func (s *StorageTestSuite) TestPowerCapMultiple() {
 	paramsA := model.PowerCapSnapshotParameter{
 		Xnames: []string{"x0c0s0b0n0", "x0c0s1b0n0"},
@@ -243,4 +243,11 @@ func (s *StorageTestSuite) TestPowerCapMultiple() {
 	s.Require().Contains([]string{opsB[0].Type, opsB[1].Type, opsB[2].Type}, "xray")
 	s.Require().Contains([]string{opsB[0].Type, opsB[1].Type, opsB[2].Type}, "yankee")
 	s.Require().Contains([]string{opsB[0].Type, opsB[1].Type, opsB[2].Type}, "zulu")
+
+	err = s.sp.DeletePowerCapTask(taskA.TaskID)
+	s.Require().NoError(err)
+
+	// the task delete should cascade delete all its operations; this op should no longer exist
+	_, err = s.sp.GetPowerCapOperation(taskA.TaskID, opA1.OperationID)
+	s.Require().ErrorContains(err, "could not retrieve power cap operation")
 }

--- a/migrations/postgres/4_create_table_power_cap.down.sql
+++ b/migrations/postgres/4_create_table_power_cap.down.sql
@@ -1,0 +1,25 @@
+-- MIT License
+--
+-- Copyright © 2025 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+DROP TABLE IF EXISTS power_cap_tasks;
+
+DROP TABLE IF EXISTS power_cap_operations;

--- a/migrations/postgres/4_create_table_power_cap.up.sql
+++ b/migrations/postgres/4_create_table_power_cap.up.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS power_cap_tasks (
 	"id" UUID PRIMARY KEY,
 	"type" VARCHAR(255) NOT NULL,
 	"created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	"expires" TIMESTAMPTZ,
+	"expires" TIMESTAMPTZ NOT NULL,
 	"status" VARCHAR(255) NOT NULL,
 	"snapshot_parameters" JSON, -- just an array of xnames, but it being embedded in a struct means we can't serialize to array directly
 	"patch_parameters" JSON,

--- a/migrations/postgres/4_create_table_power_cap.up.sql
+++ b/migrations/postgres/4_create_table_power_cap.up.sql
@@ -1,0 +1,51 @@
+-- MIT License
+--
+-- Copyright © 2025 Contributors to the OpenCHAMI Project
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS power_cap_tasks (
+	"id" UUID PRIMARY KEY,
+	"type" VARCHAR(255) NOT NULL,
+	"created" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	"expires" TIMESTAMPTZ,
+	"status" VARCHAR(255) NOT NULL,
+	"snapshot_parameters" JSON, -- just an array of xnames, but it being embedded in a struct means we can't serialize to array directly
+	"patch_parameters" JSON,
+	-- components and task_counts are only populated when compressed == true. these are completed tasks that have been
+	-- archived. components and task_counts are derived from the operations associated with this task, and summarize
+	-- those (deleted) rows.
+	"compressed" BOOL,
+	"components" JSON,
+	"task_counts" JSON
+
+);
+
+CREATE TABLE IF NOT EXISTS power_cap_operations (
+	"id" UUID PRIMARY KEY,
+	"task_id" UUID NOT NULL,
+	"type" VARCHAR(255) NOT NULL,
+	"status" VARCHAR(255) NOT NULL,
+	"component" JSON,
+	FOREIGN KEY ("task_id") REFERENCES power_cap_tasks ("id") ON DELETE CASCADE
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary and Scope

Implement the power cap functions for the Postgres storage engine and add schemas for the associated structs.

## Issues and Related PRs

Part of https://github.com/OpenCHAMI/power-control/issues/12

## Testing

New CI tests. These cover the database functions only. Downstream functions are stuck on etcd only for now per https://github.com/OpenCHAMI/power-control/issues/25.

## Commentary

### Woo, JSON everywhere!

The simple approach for these ends up using a bunch of JSON columns. I don't love these, but separate tables complicate the get/set functions a lot for one->many objects where we never query the many side directly.

### Task operation summary schema

Tasks come in two flavors, uncompressed/active and compressed/complete. When Tasks are active, they have a list of associated Operations, and API handlers fetch the Operation list to include in their response. When Tasks complete, PCS [deletes associated Operation rows and fills several Task fields with summary data](https://github.com/OpenCHAMI/power-control/blob/v2.7.0/internal/domain/power-cap.go#L1109-L1138).

I store the summary data in the Task table, which aligns with their being part of the struct. These sorta feel like they should be a separate table, but it's easier to remain close to the etcd implementation if we don't.

### Operation fields pulled from SMD

Several of the operation struct fields contain data pulled from SMD. etcd stores these fields in the database, though like anything involving etcd this is just a side effect of storing a complete JSON object under a key.

AFAICT we never reference this data after: the functions that interact with it pull from SMD every run, and overwrite the previously-pulled values. We're not authoritative for it, so I'm inclined to omit it from the Postgres schema. If we want to change this, we should consider becoming authoritative, similar to https://github.com/OpenCHAMI/power-control/issues/17

The alternative is to store it for Postgres despite.