### PR TITLE
feat: add Postgres support for comressed transitions

### DIFF
--- a/internal/storage/storage_postgres_impl.go
+++ b/internal/storage/storage_postgres_impl.go
@@ -486,9 +486,18 @@ func storeTransitionWithTx(tx *sqlx.Tx, transition model.Transition) error {
 		active,
 		expires,
 		location,
-		status
-	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	ON CONFLICT (id) DO UPDATE SET active = excluded.active, status = excluded.status`
+		status,
+		compressed,
+		task_counts,
+		tasks
+	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	ON CONFLICT (id) DO UPDATE SET
+		active = excluded.active,
+		status = excluded.status,
+		compressed = excluded.compressed,
+		task_counts = excluded.task_counts,
+		tasks = excluded.tasks
+		`
 	_, err := tx.Exec(
 		exec,
 		transition.TransitionID,
@@ -499,6 +508,9 @@ func storeTransitionWithTx(tx *sqlx.Tx, transition model.Transition) error {
 		transition.AutomaticExpirationTime,
 		transition.Location,
 		transition.Status,
+		transition.IsCompressed,
+		transition.TaskCounts,
+		transition.Tasks,
 	)
 	if err != nil {
 		return fmt.Errorf("Failed to store transition '%s': %w", transition.TransitionID, err)

--- a/migrations/postgres/2_create_table_transitions.up.sql
+++ b/migrations/postgres/2_create_table_transitions.up.sql
@@ -32,9 +32,12 @@ CREATE TABLE IF NOT EXISTS transitions (
 	"status" VARCHAR(255) NOT NULL,
 	-- An array of {xname, credential} structs. Managing these in a separate table makes data integrity more
 	-- more complicated, and we never interact with them directly like we do with transitions.
-	"location" JSON
-	-- iscompressed omitted. AFAIK this should be handled in app-side representation of the struct
-	-- taskcounts omitted. AFAIK this is also built app-side from the tasks
+	"location" JSON,
+	-- compressed transitions only. when a transition completes, domain.compressAndCompleteTransition() deletes task rows
+	-- and shoves them all into the transition.
+	"compressed" BOOL,
+	"task_counts" JSON,
+	"tasks" JSON
 );
 
 CREATE TABLE IF NOT EXISTS transition_tasks (


### PR DESCRIPTION
Add support for the various compressed transition fields to the Postgres schema. This uses the same "JSON all the things" approach as power cap.

These could maybe support keeping the original tasks (unlike power cap, transitions keep the full task set, not just a summary--although they do, for some reason, store them in API response form rather than the original struct), but it'd require domain functions have implementation-specific logic or a broader refactor, so it ain't gonna happen.

Since it's the full tasks set, the tasks JSON column could potentially be quite large, unfortunately.