### PR TITLE
Allow component field of power cap operations to be updated

### DIFF
--- a/internal/storage/storage_postgres_impl.go
+++ b/internal/storage/storage_postgres_impl.go
@@ -388,7 +388,8 @@ func (p *PostgresStorage) StorePowerCapOperation(op model.PowerCapOperation) err
 		component
 	) VALUES ($1, $2, $3, $4, $5)
 	ON CONFLICT (id) DO UPDATE SET
-	status = excluded.status
+	status = excluded.status,
+	component = excluded.component
 	`
 	_, err := p.db.Exec(
 		exec,

--- a/internal/storage/storage_postgres_power_cap_test.go
+++ b/internal/storage/storage_postgres_power_cap_test.go
@@ -140,16 +140,30 @@ func (s *StorageTestSuite) TestPowerCapOperationGetSet() {
 	s.Require().Equal(op.Status, gotOp.Status)
 	s.Require().Equal(op.Component, gotOp.Component)
 
+	newMax := 1
+	newMin := 2
+	newPup := 3
+	newComponent := model.PowerCapComponent{
+		Xname: "x0c0s0b0n0",
+		Error: "MysteriousTestError",
+		Limits: &model.PowerCapabilities{
+			HostLimitMax: &newMax,
+			HostLimitMin: &newMin,
+			PowerupPower: &newPup,
+		},
+	}
 	op.Status = "MysteriousTestStatus"
 	op.Type = "MysteriousTestType"
+	op.Component = newComponent
 	err = s.sp.StorePowerCapOperation(op)
 	s.Require().NoError(err)
 
-	// we should be able to update status, but not other fields
+	// we should be able to update status and component, but not other fields
 	gotOp, err = s.sp.GetPowerCapOperation(task.TaskID, op.OperationID)
 	s.Require().NoError(err)
 	s.Require().Equal(snapshotType, gotOp.Type)
 	s.Require().Equal("MysteriousTestStatus", gotOp.Status)
+	s.Require().Equal(newComponent, gotOp.Component)
 }
 
 // TestPowerCapTaskDelete tests deleting a single power cap task.

--- a/internal/storage/storage_provider_test.go
+++ b/internal/storage/storage_provider_test.go
@@ -1,4 +1,3 @@
-
 //go:build integration_tests
 
 package storage


### PR DESCRIPTION
This fixes failures in the CT tests. The `component` field is updated after initial creation of the power cap operation.  