### PR TITLE
fix: add migrations to image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,6 +55,7 @@ dockers:
       - CHANGELOG.md
       - README.md
       - configs/
+      - migrations/
 
   - image_templates:
       - &arm64v8_linux_image ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-arm64
@@ -74,6 +75,7 @@ dockers:
       - CHANGELOG.md
       - README.md
       - configs/
+      - migrations/
 
 docker_manifests:
   - name_template: "ghcr.io/openchami/{{.ProjectName}}:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ ENV API_BASE_PATH="/v1"
 
 COPY power-control /usr/local/bin/
 COPY configs configs
+COPY migrations migrations
 
 #nobody 65534:65534
 USER 65534:65534


### PR DESCRIPTION
Built an image off the tip of main while writing some deploy tooling and discovered the migrations Job didn't really work because:

```
time="2025-07-21T23:42:24Z" level=fatal msg="ERROR: Failed to create migration: failed to open source, \"file://./migrations/postgres\": open .: no such file or directory"
```
This makes that available at the expected location.