### PR TITLE
fix: default compressed to false in SQL

### DIFF
--- a/migrations/postgres/2_create_table_transitions.up.sql
+++ b/migrations/postgres/2_create_table_transitions.up.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS transitions (
 	"location" JSON,
 	-- compressed transitions only. when a transition completes, domain.compressAndCompleteTransition() deletes task rows
 	-- and shoves them all into the transition.
-	"compressed" BOOL,
+	"compressed" BOOL NOT NULL DEFAULT FALSE,
 	"task_counts" JSON,
 	"tasks" JSON
 );

--- a/migrations/postgres/4_create_table_power_cap.up.sql
+++ b/migrations/postgres/4_create_table_power_cap.up.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS power_cap_tasks (
 	-- components and task_counts are only populated when compressed == true. these are completed tasks that have been
 	-- archived. components and task_counts are derived from the operations associated with this task, and summarize
 	-- those (deleted) rows.
-	"compressed" BOOL,
+	"compressed" BOOL NOT NULL DEFAULT FALSE,
 	"components" JSON,
 	"task_counts" JSON
 


### PR DESCRIPTION
## Summary and Scope

Ensure "compressed" bool fields always have a value in SQL. Plain bool types cannot serialize SQL NULL bool, and we want to preserve the original type.

Modifies Postgres migrations, but those haven't been formally released yet, so added to the original `CREATE TABLE`.

## Issues and Related PRs

Found (and then forgot to copy) errors re not being able to coerce null to bool when [domain attempts to get transitions](https://github.com/OpenCHAMI/power-control/blob/0046c4129e8744a5b4e2a5f2371b8e51164e435e/internal/domain/transitions.go#L119).

Since we're not using a pointer or a special type, this doesn't work: https://stackoverflow.com/questions/26976251/how-can-i-fetch-a-null-boolean-from-postgres-in-go

I want to preserve the original type in the model struct, and we have no obvious reason to need null bools, so default seems the way to go.

## Testing

The CLI transition get works now:

```
$  ochami pcs transition show 233b2629-d2c9-4ae1-b36e-78c6fbe56e85 | jq                                                                                                                                                                                               
{                                                                                                                                                                                                                                                                                              
  "automaticExpirationTime": "2025-07-31T21:17:36.309528Z",                                                                                                                                                                                                                                    
  "createTime": "2025-07-30T21:17:36.309527Z",                                                                                                                                                                                                                                                 
  "operation": "Soft-Restart",                                                                                                                                                                                                                                                                 
  "taskCounts": {                                                                                                                                                                                                                                                                              
    "failed": 0,                                                                                                                                                                                                                                                                               
    "in-progress": 1,                                                                                                                                                                                                                                                                          
    "new": 0,                                                                                                                                                                                                                                                                                  
    "succeeded": 0,                                                                                                                                                                                                                                                                            
    "total": 1,                                                                                                                                                                                                                                                                                
    "un-supported": 0                                                                                                                                                                                                                                                                          
  },                                                                                                                                                                                                                                                                                           
  "tasks": [                                                                                                                                                                                                                                                                                   
    {                                                                                                                                                                                                                                                                                          
      "taskStatus": "in-progress",                                                                                                                                                                                                                                                             
      "taskStatusDescription": "Confirming successful transition, gracefulshutdown",                                                                                                                                                                                                           
      "xname": "x1403c7s6b0n1"                                                                                                                                                                                                                                                                 
    }                                                                                                                                                                                                                                                                                          
  ],                                                                                                                                                                                                                                                                                           
  "transitionID": "233b2629-d2c9-4ae1-b36e-78c6fbe56e85",                                                                                                                                                                                                                                      
  "transitionStatus": "in-progress"                                                                                                                                                                                                                                                            
}
```
it got 500s before.