### PR TITLE
Switch to shared workflow

### DIFF
--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -1,79 +1,20 @@
 name: Release with goreleaser
 
 on:
+  workflow_dispatch:
+  pull_request:
   push:
     tags:
       - v*
 
-permissions: write-all # Necessary for the generate-build-provenance action with containers
-
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install cross-compilation tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-
-      - name: Set up latest stable Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Checkout out the repo
-        uses: actions/checkout@v4
-        with:
-          fetch-tags: 1
-          fetch-depth: 1
-
-      # Set environment variables required by GoReleaser
-      - name: Set build environment variables
-        run: |
-          echo "GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)" >> $GITHUB_ENV
-          echo "BUILD_HOST=$(hostname)" >> $GITHUB_ENV
-          echo "GO_VERSION=$(go version | awk '{print $3}')" >> $GITHUB_ENV
-          echo "BUILD_USER=$(whoami)" >> $GITHUB_ENV
-
-      - name: Docker Login
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Release with goreleaser
-        uses: goreleaser/goreleaser-action@v6
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          version: '~> v2'
-          args: release --clean
-        id: goreleaser
-
-      - name: Process goreleaser output
-        id: process_goreleaser_output
-        run: |
-          echo "const fs = require('fs');" > process.js
-          echo 'const artifacts = ${{ steps.goreleaser.outputs.artifacts }}' >> process.js
-          echo "const firstNonNullDigest = artifacts.find(artifact => artifact.extra && artifact.extra.Digest != null)?.extra.Digest;" >> process.js
-          echo "console.log(firstNonNullDigest);" >> process.js
-          echo "fs.writeFileSync('digest.txt', firstNonNullDigest);" >> process.js
-          node process.js
-          echo "digest=$(cat digest.txt)" >> $GITHUB_OUTPUT
-
-      - name: Attest power-control binary amd64
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: dist/pcs_linux_amd64_v3/power-control
-      - name: Attest power-control binary arm64
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: dist/pcs_linux_arm64_v8.0/power-control
-      - name: Generate build provenance
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-name: ghcr.io/openchami/pcs
-          subject-digest: ${{ steps.process_goreleaser_output.outputs.digest }}
-          push-to-registry: true
+  release:
+    uses: openchami/github-actions/.github/workflows/go-build-release.yml@3.2
+    with:
+      fetch-depth: 1
+      pre-build-commands: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      goreleaser-version: "~> v2"
+      attestation-binary-path: "dist/pcs_linux_amd64_v3/power-control, dist/pcs_linux_arm64_v8.0/power-control"
+      registry-name: ghcr.io/openchami/pcs

--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: openchami/github-actions/.github/workflows/go-build-release.yml@3.2
+    uses: OpenCHAMI/github-actions/.github/workflows/go-build-release.yml@v3.2
     with:
       fetch-depth: 1
       pre-build-commands: |

--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -1,4 +1,4 @@
-name: Release with goreleaser
+name: Build and Release Image
 
 on:
   workflow_dispatch:
@@ -6,6 +6,8 @@ on:
   push:
     tags:
       - v*
+
+permissions: write-all # Necessary for the generate-build-provenance action with containers
 
 jobs:
   release:


### PR DESCRIPTION
## Summary and Scope

Similar to https://github.com/OpenCHAMI/cloud-init/pull/82 

Uses the new re-usable workflow for goreleaser builds 

## Testing

No changes to code itself only the build workflow.
All previous build logic is preserved 

PR creation should trigger a snapshot build. 