### PR TITLE
Add a fake credential store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for pprof builds
+- Added a fake Vault drop-in credential store to set credentials from the environment.
 
 ### Changes
 

--- a/cmd/power-control/commands.go
+++ b/cmd/power-control/commands.go
@@ -71,6 +71,7 @@ func createRootCommand(pcs *pcsConfig, etcd *etcdConfig, postgres *storage.Postg
 	rootCommand.Flags().StringVar(&pcs.stateManagerServer, "sms-server", defaultSMSServer, "SMS Server")
 	rootCommand.Flags().BoolVar(&pcs.runControl, "run-control", pcs.runControl, "run control loop; false runs API only") //this was a flag useful for dev work
 	rootCommand.Flags().BoolVar(&pcs.hsmLockEnabled, "hsmlock-enabled", true, "Use HSM Locking")                         // This was a flag useful for dev work
+	rootCommand.Flags().BoolVar(&pcs.fakeVaultEnabled, "fake-vault-enabled", false, fmt.Sprintf("Use a mock credential store that uses %s and %s for all BMCs.", fakeVaultUserEnv, fakeVaultPasswordEnv))
 	rootCommand.Flags().BoolVar(&pcs.vaultEnabled, "vault-enabled", true, "Should vault be used for credentials?")
 	rootCommand.Flags().StringVar(&pcs.vaultKeypath, "vault-keypath", "secret/hms-creds",
 		"Keypath for Vault credentials.")

--- a/internal/credstore/credstore.go
+++ b/internal/credstore/credstore.go
@@ -32,6 +32,26 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type MockStore struct {
+	Username, Password string
+}
+
+func (s *MockStore) Init(_ *CREDSTORE_GLOBALS) {
+	return
+}
+
+func (s *MockStore) IsReady() bool {
+	return true
+}
+
+func (s *MockStore) GetCredentials(_ string) (string, string, error) {
+	return s.Username, s.Password, nil
+}
+
+func (s *MockStore) GetControllerCredentials(_ string) (string, string, error) {
+	return s.GetCredentials("")
+}
+
 func (b *VAULTv0) Init(globals *CREDSTORE_GLOBALS) {
 	b.CredStoreGlobals = CREDSTORE_GLOBALS{}
 	b.CredStoreGlobals = *globals

--- a/internal/credstore/credstore_test.go
+++ b/internal/credstore/credstore_test.go
@@ -1,0 +1,24 @@
+package credstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockStore(t *testing.T) {
+	username := "testname"
+	password := "testpass"
+
+	testStore := MockStore{
+		Username: username,
+		Password: password,
+	}
+
+	require.True(t, testStore.IsReady())
+
+	gotUser, gotPass, gotError := testStore.GetCredentials("")
+	require.NoError(t, gotError)
+	require.Equal(t, username, gotUser)
+	require.Equal(t, password, gotPass)
+}


### PR DESCRIPTION
## Summary and Scope

Don't want to bother with Vault in your test environment? No problem! Just stick the Redfish credentials in the environment.

Backwards-compatible.

## Issues and Related PRs

Related to https://github.com/OpenCHAMI/roadmap/issues/74 sorta. This adds the simplest possible alternative and adds inline commentary about why doing it properly probably requires breaking changes.

This came out of wanting to create an insecure test environment for PCS without needing to set up Vault and populate credentials, which is useful for testing interactions with SMD and the BMC in before we have the "provision Vault and fill credentials" part of https://github.com/OpenCHAMI/roadmap/issues/74 figured out.

## Testing

While this adds a unit test, it's incredibly boring, because the feature itself is incredibly simple.

Changes to the CLI cmd package are more complicated. cmd isn't easily in a place where we can easily unit test it, but existing CT tests continuing to work confirm that PCS still honors the original Vault configuration if you do not enable fake Vault.

Manual test info forthcoming. I don't want to try and rejigger CT to support either, and this is part of a chicken-before-egg series of PRs where I want it up before adding another PR that explains the test procedure.

## Risks and Mitigations

This adds an argument and two related env-only inputs to UX surface.

I expect to need to break these later as part of broader work to implement https://github.com/OpenCHAMI/roadmap/issues/74 with proper alternate cred stores. I don't really mind breaking that UX, as this shouldn't really be used outside development work, and the utility of having a quick and ugly solution now outweighs the annoyance of breaking dev workflows later.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable