### PR TITLE
Ensure reservation calls use HTTP client with oauth2 enabled

### DIFF
--- a/internal/hsm/state_manager.go
+++ b/internal/hsm/state_manager.go
@@ -112,7 +112,15 @@ func (b *HSMv2) Init(globals *HSM_GLOBALS) error {
 		logy.SetFormatter(Formatter)
 
 		b.HSMGlobals.Reservation = &reservation.Production{}
-		b.HSMGlobals.Reservation.InitInstance(b.HSMGlobals.SMUrl, "", 1, logy, svcName)
+
+		// Select the HTTP client to use
+		httpClient := b.HSMGlobals.SVCHttpClient.InsecureClient
+		if b.HSMGlobals.SVCHttpClient.SecureClient != nil {
+			httpClient = b.HSMGlobals.SVCHttpClient.SecureClient
+		}
+
+		// Initialize the reservation production instance with our http client, so  bearer tokens are added to requests
+		b.HSMGlobals.Reservation.InitWithHTTPClient(b.HSMGlobals.SMUrl, "", 1, logy, svcName, httpClient)
 	}
 
 	//Make sure certain things are set up


### PR DESCRIPTION
## Summary and Scope

Use new function in SMD to initialize reservation production instance with PCS HTTP client instance, so the correct access tokens are added.

## Testing

Ran PCS CT suite with OAuth2 enabled, all test passed.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable