### PR TITLE
Allow SMD metadata to be updated

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/internal/domain/power-status.go
+++ b/internal/domain/power-status.go
@@ -363,9 +363,17 @@ func updateComponentMap() error {
 		case xnametypes.CDUMgmtSwitch:
 			fallthrough
 		case xnametypes.CabinetPDUPowerConnector:
-			_, ok := hwStateMap[v.BaseData.ID]
-			if !ok {
-				//New component.
+			existing, ok := hwStateMap[v.BaseData.ID]
+			if ok {
+				// Refresh HSM metadata in place so late discovery updates
+				// populate entries created before ComponentEndpoints existed
+				existing.HSMData.RfFQDN = v.RfFQDN
+				existing.HSMData.PowerStatusURI = v.PowerStatusURI
+				existing.HSMData.PowerActionURI = v.PowerActionURI
+				existing.HSMData.PowerCapURI = v.PowerCapURI
+				existing.PSComp.SupportedPowerTransitions = toPCSPowerActions(v.AllowableActions)
+			} else {
+				// New component.
 				newComp := componentPowerInfo{}
 				newComp.PSComp.XName = v.BaseData.ID
 				newComp.PSComp.PowerState = pcsmodel.PowerStateFilter_Undefined.String()


### PR DESCRIPTION
Previously entries to the state map where only added, not updated. So when State/Components data is present in SMD but its matching ComponentEndpoint is not yet populated, FillHSMData returns a HsmData with the basic fields filled but RfFQDN / PowerStatusURI / PowerActionURI blank. These blank fields could not then be updated by subsequent calls.

Fixes: #66 