### PR TITLE
chore: disable ARM builds pending fix

### DIFF
--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -30,14 +30,16 @@ jobs:
       cgo-enabled: 1
       platforms: "linux/amd64"
       docker-file: "Dockerfile.build"
-  image_arm:
-    name: Build ARM Image
-    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@v3.3
-    with:
-      fetch-depth: 1
-      registry-name: ghcr.io/openchami/pcs
-      cgo-enabled: 1
-      additional-env-vars: |
-        CC=aarch64-linux-gnu-gcc
-      platforms: "linux/arm64"
-      docker-file: "Dockerfile.build"
+# Disabled! This is busted: multiple steps that push independently break the multi-arch manifest:
+# https://github.com/OpenCHAMI/power-control/issues/58#issuecomment-4502102485
+#  image_arm:
+#    name: Build ARM Image
+#    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@v3.3
+#    with:
+#      fetch-depth: 1
+#      registry-name: ghcr.io/openchami/pcs
+#      cgo-enabled: 1
+#      additional-env-vars: |
+#        CC=aarch64-linux-gnu-gcc
+#      platforms: "linux/arm64"
+#      docker-file: "Dockerfile.build"


### PR DESCRIPTION
See https://github.com/OpenCHAMI/power-control/issues/58#issuecomment-4502102485

Building and pushing ARM in its own step clobbers the manifest, so there's no way to get the amd64 image. It _may_ still be available (there's an `unknown/unknown` image present per GHCR info), but there's no way to actually pull it.

Disabling ARM so that `main` builds get amd64 can provide a temporary workaround.