### PR TITLE
Fix multi-arch container builds by consolidating build jobs

### DIFF
--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -23,11 +23,11 @@ permissions: write-all # Necessary for the generate-build-provenance action with
 jobs:
   image:
     name: Build & Push Multi-arch Image
-    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@v3.3
+    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@feature/multi-arch-build-refinements@feature/multi-arch-build-refinements
     with:
       fetch-depth: 1
       registry-name: ghcr.io/openchami/pcs
       cgo-enabled: 1
       platforms: "linux/amd64,linux/arm64"
       docker-file: "Dockerfile.build"
-      # Don't pass CC here - let the Dockerfile set it based on TARGETARCH
+      image-description: "Multi-architecture power control service for OpenCHAMI (supports linux/amd64 and linux/arm64)"

--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -23,7 +23,7 @@ permissions: write-all # Necessary for the generate-build-provenance action with
 jobs:
   image:
     name: Build & Push Multi-arch Image
-    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@feature/multi-arch-build-refinements
+    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@v3.4
     with:
       fetch-depth: 1
       registry-name: ghcr.io/openchami/pcs

--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -22,22 +22,15 @@ permissions: write-all # Necessary for the generate-build-provenance action with
 
 jobs:
   image:
-    name: Build Image
+    name: Build & Push Multi-arch Image
     uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@v3.3
     with:
       fetch-depth: 1
       registry-name: ghcr.io/openchami/pcs
       cgo-enabled: 1
-      platforms: "linux/amd64"
+      # Build both amd64 and arm64 in a single run – Docker Buildx will create a manifest list.
+      platforms: "linux/amd64,linux/arm64"
       docker-file: "Dockerfile.build"
-  image_arm:
-    name: Build ARM Image
-    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@v3.3
-    with:
-      fetch-depth: 1
-      registry-name: ghcr.io/openchami/pcs
-      cgo-enabled: 1
+      # The arm64 build needs the cross-compiler; the amd64 build simply ignores it.
       additional-env-vars: |
         CC=aarch64-linux-gnu-gcc
-      platforms: "linux/arm64"
-      docker-file: "Dockerfile.build"

--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -30,4 +30,4 @@ jobs:
       cgo-enabled: 1
       platforms: "linux/amd64,linux/arm64"
       docker-file: "Dockerfile.build"
-      image-description: "Multi-architecture power control service for OpenCHAMI (supports linux/amd64 and linux/arm64)"
+      image-description: "OpenCHAMI Power Control Service"

--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -28,9 +28,6 @@ jobs:
       fetch-depth: 1
       registry-name: ghcr.io/openchami/pcs
       cgo-enabled: 1
-      # Build both amd64 and arm64 in a single run – Docker Buildx will create a manifest list.
       platforms: "linux/amd64,linux/arm64"
       docker-file: "Dockerfile.build"
-      # The arm64 build needs the cross-compiler; the amd64 build simply ignores it.
-      additional-env-vars: |
-        CC=aarch64-linux-gnu-gcc
+      # Don't pass CC here - let the Dockerfile set it based on TARGETARCH

--- a/.github/workflows/upstream-docker-release.yml
+++ b/.github/workflows/upstream-docker-release.yml
@@ -23,7 +23,7 @@ permissions: write-all # Necessary for the generate-build-provenance action with
 jobs:
   image:
     name: Build & Push Multi-arch Image
-    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@feature/multi-arch-build-refinements@feature/multi-arch-build-refinements
+    uses: OpenCHAMI/github-actions/.github/workflows/docker-build-release.yml@feature/multi-arch-build-refinements
     with:
       fetch-depth: 1
       registry-name: ghcr.io/openchami/pcs

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -20,8 +20,9 @@ RUN printf "Building for TARGETPLATFORM=${TARGETPLATFORM}" \
     && printf "With 'uname -s': $(uname -s) and 'uname -m': $(uname -m)"
 
 # Install cross-compilation dependencies
+# Install build-essential for native compilation and aarch64 cross-compiler for ARM builds
 RUN apt-get update && \
-    apt-get install -y g++-aarch64-linux-gnu && \
+    apt-get install -y build-essential g++-aarch64-linux-gnu && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /workspace
@@ -52,20 +53,17 @@ ARG CGO_ENABLED
 
 RUN mkdir bin
 
-# Use shell parameter expansion to add -ldflags if CC is set to specify the external linker
-# For arm64, use the cross-compiler; for amd64, use the default compiler
-RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-      CGO_ENABLED="${CGO_ENABLED}" \
-      GOOS=linux \
-      GOARCH="${TARGETARCH}" \
-      CC="${CC}" \
-      GO111MODULE=on \
+# Build the binary with appropriate cross-compilation settings
+# For arm64, use the cross-compiler; for amd64, use the default toolchain
+RUN set -ex && \
+    export CGO_ENABLED="${CGO_ENABLED}" && \
+    export GOOS=linux && \
+    export GOARCH="${TARGETARCH}" && \
+    export GO111MODULE=on && \
+    if [ "${TARGETARCH}" = "arm64" ]; then \
+      export CC="${CC:-aarch64-linux-gnu-gcc}" && \
       go build -ldflags="-extld=${CC}" -v -o bin/power-control ./cmd/power-control; \
     else \
-      CGO_ENABLED="${CGO_ENABLED}" \
-      GOOS=linux \
-      GOARCH="${TARGETARCH}" \
-      GO111MODULE=on \
       go build -v -o bin/power-control ./cmd/power-control; \
     fi
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -53,12 +53,21 @@ ARG CGO_ENABLED
 RUN mkdir bin
 
 # Use shell parameter expansion to add -ldflags if CC is set to specify the external linker
-RUN CGO_ENABLED="${CGO_ENABLED}" \
-    GOOS=linux \
-    GOARCH="${TARGETARCH}" \
-    CC="${CC}" \
-    GO111MODULE=on \
-    go build ${CC:+-ldflags="-extld=$CC"} -v -o bin/power-control ./cmd/power-control
+# For arm64, use the cross-compiler; for amd64, use the default compiler
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+      CGO_ENABLED="${CGO_ENABLED}" \
+      GOOS=linux \
+      GOARCH="${TARGETARCH}" \
+      CC="${CC}" \
+      GO111MODULE=on \
+      go build -ldflags="-extld=${CC}" -v -o bin/power-control ./cmd/power-control; \
+    else \
+      CGO_ENABLED="${CGO_ENABLED}" \
+      GOOS=linux \
+      GOARCH="${TARGETARCH}" \
+      GO111MODULE=on \
+      go build -v -o bin/power-control ./cmd/power-control; \
+    fi
 
 ### release image
 # TODO seems kinda off that we don't pin wolfi or tini, but whatever

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -78,7 +78,7 @@ FROM chainguard/wolfi-base:latest AS main
 
 # OCI labels for better container metadata
 LABEL org.opencontainers.image.title="OpenCHAMI Power Control Service" \
-      org.opencontainers.image.description="Multi-architecture power control service for OpenCHAMI (supports linux/amd64 and linux/arm64)" \
+      org.opencontainers.image.description="OpenCHAMI Power Control Service" \
       org.opencontainers.image.vendor="OpenCHAMI" \
       org.opencontainers.image.source="https://github.com/OpenCHAMI/power-control" \
       org.opencontainers.image.documentation="https://github.com/OpenCHAMI/power-control/blob/main/README.md" \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -76,6 +76,14 @@ RUN set -ex && \
 # TODO seems kinda off that we don't pin wolfi or tini, but whatever
 FROM chainguard/wolfi-base:latest AS main
 
+# OCI labels for better container metadata
+LABEL org.opencontainers.image.title="OpenCHAMI Power Control Service" \
+      org.opencontainers.image.description="Multi-architecture power control service for OpenCHAMI (supports linux/amd64 and linux/arm64)" \
+      org.opencontainers.image.vendor="OpenCHAMI" \
+      org.opencontainers.image.source="https://github.com/OpenCHAMI/power-control" \
+      org.opencontainers.image.documentation="https://github.com/OpenCHAMI/power-control/blob/main/README.md" \
+      org.opencontainers.image.licenses="MIT"
+
 RUN set -ex \
     && apk update \
     && apk add --no-cache tini \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -54,16 +54,21 @@ ARG CGO_ENABLED
 RUN mkdir bin
 
 # Build the binary with appropriate cross-compilation settings
-# For arm64, use the cross-compiler; for amd64, use the default toolchain
+# Set CC based on target architecture (don't rely on build args for multi-arch builds)
 RUN set -ex && \
+    echo "Building for TARGETARCH=${TARGETARCH}" && \
     export CGO_ENABLED="${CGO_ENABLED}" && \
     export GOOS=linux && \
     export GOARCH="${TARGETARCH}" && \
     export GO111MODULE=on && \
     if [ "${TARGETARCH}" = "arm64" ]; then \
-      export CC="${CC:-aarch64-linux-gnu-gcc}" && \
+      echo "Using ARM64 cross-compiler" && \
+      export CC="aarch64-linux-gnu-gcc" && \
+      echo "CC is now: ${CC}" && \
       go build -ldflags="-extld=${CC}" -v -o bin/power-control ./cmd/power-control; \
     else \
+      echo "Using native amd64 compiler" && \
+      echo "Building without external CC" && \
       go build -v -o bin/power-control ./cmd/power-control; \
     fi
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Power Control Service(pcs)
+# Power Control Service (pcs)
 
 This is a fork of the original PCS code from [Cray-HPE/hms-power-control](https://github.com/Cray-HPE/hms-power-control). It adds support for Postgres operation.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,3 @@
 # Power Control Service(pcs)
 
 This is a fork of the original PCS code from [Cray-HPE/hms-power-control](https://github.com/Cray-HPE/hms-power-control), suitable only for experimentation and demo purposes at this point.
-
-## Build/Install with goreleaser
-
-This project uses [GoReleaser](https://goreleaser.com/) to automate releases and include additional build metadata such as commit info, build time, and versioning. Below is a guide on how to set up and build the project locally using GoReleaser.
-
-### Environment Variables
-
-To include detailed build metadata, ensure the following environment variables are set:
-
-* __GIT_STATE__: Indicates whether there are uncommitted changes in the working directory. Set to clean if the repository is clean, or dirty if there are uncommitted changes.
-* __BUILD_HOST__: The hostname of the machine where the build is being performed.
-* __GO_VERSION__: The version of Go used for the build. GoReleaser uses this to ensure consistent Go versioning information.
-* __BUILD_USER__: The username of the person or system performing the build.
-
-Set all the environment variables with:
-```bash
-export GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)
-export BUILD_HOST=$(hostname)
-export GO_VERSION=$(go version | awk '{print $3}')
-export BUILD_USER=$(whoami)
-```
-
-### Building Locally with GoReleaser
-
-Once the environment variables are set, you can build the project locally using GoReleaser in snapshot mode (to avoid publishing).
-
-
-Follow the installation instructions from [GoReleaser’s documentation](https://goreleaser.com/install/).
-
-1. Run GoReleaser in snapshot mode with the --snapshot flag to create a local build without attempting to release it:
-  ```bash
-  goreleaser release --snapshot --clean
-  ```
-2.	Check the dist/ directory for the built binaries, which will include the metadata from the environment variables. You can inspect the binary output to confirm that the metadata was correctly embedded.
-
-__NOTE__ If you see errors, ensure that you are using the same version of goreleaser that is being used in the [Release Action](.github/workflows/Release.yml)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Power Control Service(pcs)
 
-This is a fork of the original PCS code from [Cray-HPE/hms-power-control](https://github.com/Cray-HPE/hms-power-control), suitable only for experimentation and demo purposes at this point.
+This is a fork of the original PCS code from [Cray-HPE/hms-power-control](https://github.com/Cray-HPE/hms-power-control). It adds support for Postgres operation.


### PR DESCRIPTION
Replace separate amd64/arm64 jobs with single multi-platform build to produce proper manifest list. Prevents tag overwrites and enables automatic platform selection when pulling images.