### PR TITLE
fix: remove stale HSM provider dereference

### DIFF
--- a/internal/domain/power-status.go
+++ b/internal/domain/power-status.go
@@ -1140,7 +1140,7 @@ func updateSmdPowerState(updatedComponents []pcsmodel.PowerStatusComponent) erro
 			continue
 		}
 
-		err := (*hsmHandle).BulkComponentStateUpdate(components, state)
+		err := hsmHandle.BulkComponentStateUpdate(components, state)
 		if err != nil {
 			return fmt.Errorf("Error performing SMD bulk state update: %v", err)
 		}


### PR DESCRIPTION
Fix a compile error introduced by #29, where HSMProvider was changed from a pointer-to-interface to an interface but one place still dereferenced it, this was introduced while the PR was in progress.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable