### PR TITLE
chore: update build and lint tooling to Go 1.25

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,4 +19,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.12.2

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,7 +2,7 @@
 # Build the binary
 # TODO this needs to match go.mod. Unsure how they can be
 # kept in sync.
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 ARG GOPATH
 ARG GOCACHE

--- a/Dockerfile.ct.Dockerfile
+++ b/Dockerfile.ct.Dockerfile
@@ -23,7 +23,7 @@
 # Dockerfile for building power-control.
 
 # Build base just has the packages installed we need.
-FROM docker.io/library/golang:1.24-alpine AS build-base
+FROM docker.io/library/golang:1.25-alpine AS build-base
 
 RUN set -ex \
     && apk -U upgrade \

--- a/Dockerfile.test.unit.Dockerfile
+++ b/Dockerfile.test.unit.Dockerfile
@@ -22,7 +22,7 @@
 
 # This file only exists as a means to run tests in an automated fashion.
 
-FROM docker.io/library/golang:1.24-alpine
+FROM docker.io/library/golang:1.25-alpine
 
 RUN set -ex \
     && apk -U upgrade \


### PR DESCRIPTION
This is needed to unstick #80, we need to bump lint, but the newer version use 1.25.